### PR TITLE
Add vouch GitHub Actions and VOUCHED.td with charlenenicer

### DIFF
--- a/.github/scripts/update-floating-tags.nu
+++ b/.github/scripts/update-floating-tags.nu
@@ -1,0 +1,75 @@
+#!/usr/bin/env nu
+
+# Update floating major-version tags to point to the latest matching semver release.
+#
+# For each semver tag (e.g. v1.2.3), determines the latest release per major
+# version and creates or force-updates the corresponding floating tag (e.g. v1).
+#
+# Examples:
+#
+# # Preview what would happen (default)
+# nu .github/scripts/floating-tags.nu
+#
+# # Actually update the tags
+# nu .github/scripts/floating-tags.nu --dry-run=false
+
+export def main [
+  --dry-run = true, # Print what would happen without making changes
+] {
+  let tags = semver-tags
+
+  if ($tags | is-empty) {
+    print "No semver tags found"
+    return
+  }
+
+  let grouped = $tags
+    | each { |t| parse-semver $t }
+    | group-by major
+    | items { |major, entries|
+      let latest = $entries | sort-by major minor patch | last
+      { major: $"v($major)", tag: $latest.raw }
+    }
+
+  for entry in $grouped {
+    let target = ^git rev-parse $entry.tag | str trim
+    let existing = try {
+      ^git rev-parse $entry.major err>/dev/null | str trim
+    } catch {
+      null
+    }
+
+    if $existing == $target {
+      print $"($entry.major) -> ($entry.tag) (already up to date)"
+      continue
+    }
+
+    if $dry_run {
+      print $"(char lparen)dry-run(char rparen) git tag -fa ($entry.major) ($target) -m ($entry.tag)"
+      print $"(char lparen)dry-run(char rparen) git push origin ($entry.major) --force"
+      continue
+    }
+
+    ^git tag -fa $entry.major $target -m $entry.tag
+    ^git push origin $entry.major --force
+    print $"Updated ($entry.major) -> ($entry.tag)"
+  }
+}
+
+# List all semver tags sorted by version descending.
+def semver-tags [] {
+  ^git tag --list --sort=-v:refname
+    | lines
+    | where { |t| $t =~ '^v\d+\.\d+\.\d+$' }
+}
+
+# Parse a semver tag string into a record.
+def parse-semver [tag: string] {
+  let parts = $tag | str replace "v" "" | split row "."
+  {
+    raw: $tag,
+    major: ($parts | get 0 | into int),
+    minor: ($parts | get 1 | into int),
+    patch: ($parts | get 2 | into int),
+  }
+}

--- a/.github/workflows/update-floating-tags.yml
+++ b/.github/workflows/update-floating-tags.yml
@@ -1,0 +1,26 @@
+name: Update Floating Tags
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  update-floating-tags:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - uses: hustcer/setup-nu@920172d92eb04671776f3ba69d605d3b09351c30 # v3.22
+        with:
+          version: "*"
+
+      - run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - run: nu .github/scripts/update-floating-tags.nu --dry-run=false

--- a/VOUCHED.td
+++ b/VOUCHED.td
@@ -1,0 +1,22 @@
+# The list of vouched (or actively denounced) users for this repository.
+#
+# The high-level idea is that only vouched users can participate in
+# contributing to this project. And a denounced user is explicitly
+# blocked from contributing (issues, PRs, etc. auto-closed).
+#
+# We choose to maintain a denouncement list rather than or in addition to
+# using the platform's block features so other projects can slurp in our
+# list of denounced users if they trust us and want to adopt our prior
+# knowledge about bad actors.
+#
+# Syntax:
+# - One handle per line (without @). Sorted alphabetically.
+# - Optionally specify platform: `platform:username` (e.g., `github:mitchellh`).
+# - To denounce a user, prefix with minus: `-username` or `-platform:username`.
+# - Optionally, add details after a space following the handle.
+#
+# Maintainers can vouch for new contributors by commenting "lgtm" on an
+# issue by the author. Maintainers can denounce users by commenting
+# "denounce" or "denounce [username]" on an issue or PR.
+
+charlenenicer


### PR DESCRIPTION
- .github/scripts/update-floating-tags.nu: Nushell script that updates floating major-version tags (e.g. v1) to point to the latest semver release (e.g. v1.2.3) on each publish.
- .github/workflows/update-floating-tags.yml: workflow that runs the script automatically on release published, or manually via dispatch.
- VOUCHED.td: vouched users list with charlenenicer as the first entry.

https://claude.ai/code/session_01Lhn9S3jJDBPihHNVXkwrok